### PR TITLE
Bugfix - ReadFrom return 0 (not -1)

### DIFF
--- a/client.go
+++ b/client.go
@@ -752,7 +752,7 @@ func (f *RemoteFile) readAt(b []byte, off int64) (n int, err error) {
 				if err, ok := err.(*ResponseError); ok && NtStatus(err.Code) == STATUS_END_OF_FILE && n != 0 {
 					return n, nil
 				}
-				return -1, err
+				return 0, err
 			}
 
 			n += copy(b[n:], bs)
@@ -766,7 +766,7 @@ func (f *RemoteFile) readAt(b []byte, off int64) (n int, err error) {
 				if err, ok := err.(*ResponseError); ok && NtStatus(err.Code) == STATUS_END_OF_FILE && n != 0 {
 					return n, nil
 				}
-				return -1, err
+				return 0, err
 			}
 
 			n += copy(b[n:], bs)
@@ -918,7 +918,7 @@ func (f *RemoteFile) serverSeek(offset int64, whence int) (ret int64, err error)
 		req := &QueryInfoRequest{
 			FileInfoClass:         FilePositionInformation,
 			AdditionalInformation: 0,
-			Flags: 0,
+			Flags:                 0,
 		}
 
 		infoBytes, err := f.queryInfo(req)
@@ -940,7 +940,7 @@ func (f *RemoteFile) serverSeek(offset int64, whence int) (ret int64, err error)
 		req := &QueryInfoRequest{
 			FileInfoClass:         FileStandardInformation,
 			AdditionalInformation: 0,
-			Flags: 0,
+			Flags:                 0,
 		}
 
 		infoBytes, err := f.queryInfo(req)
@@ -984,7 +984,7 @@ func (f *RemoteFile) clientSeek(offset int64, whence int) (ret int64, err error)
 		req := &QueryInfoRequest{
 			FileInfoClass:         FileStandardInformation,
 			AdditionalInformation: 0,
-			Flags: 0,
+			Flags:                 0,
 		}
 
 		infoBytes, err := f.queryInfo(req)
@@ -1017,7 +1017,7 @@ func (f *RemoteFile) stat() (os.FileInfo, error) {
 	req := &QueryInfoRequest{
 		FileInfoClass:         FileAllInformation,
 		AdditionalInformation: 0,
-		Flags: 0,
+		Flags:                 0,
 	}
 
 	infoBytes, err := f.queryInfo(req)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/hirochachacha/go-smb2
+
+go 1.12
+
+require golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,9 @@
+github.com/hirochachacha/go-smb2 v0.0.0-20170105012046-2cbb6a7d134e h1:XS78dHYNlaxlmuE6yTtQffc/BrIEOmJj9rIDcFb2ElY=
+github.com/hirochachacha/go-smb2 v0.0.0-20170105012046-2cbb6a7d134e/go.mod h1:RU3w0c0Bf9WHJ5OhUp7xefZwrmGTNUx49pSwNUEK2FA=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 h1:HuIa8hRrWRSrqYzx1qI49NNxhdi2PrY7gxVSq1JjLDc=
+golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
At Golang 1.10 (or above), It make a panic that io.Reader.ReadFrom returns
negative count value.
Fix : Return 0 event if error.

https://github.com/golang/go/blob/master/src/bytes/buffer.go#L206
golang/go@07e36af