### PR TITLE
Bugfix - NegotiageContextOffset and List handle only if DialectRevision

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -148,6 +148,11 @@ retry:
 	// conn.clientGuid = n.ClientGuid
 	// copy(conn.serverGuid[:], r.ServerGuid())
 
+	if conn.dialect != SMB311 {
+		return conn, nil
+	}
+
+	// handle context for SMB311
 	list := r.NegotiateContextList()
 	for count := r.NegotiateContextCount(); count > 0; count-- {
 		ctx := NegotiateContextDecoder(list)

--- a/internal/smb2/response.go
+++ b/internal/smb2/response.go
@@ -392,14 +392,16 @@ func (r NegotiateResponseDecoder) IsInvalid() bool {
 		return true
 	}
 
-	noff := r.NegotiateContextOffset()
+	if r.DialectRevision() == SMB311 {
+		noff := r.NegotiateContextOffset()
 
-	if noff&7 != 0 {
-		return true
-	}
+		if noff&7 != 0 {
+			return true
+		}
 
-	if len(r) < int(noff)-64 {
-		return true
+		if len(r) < int(noff)-64 {
+			return true
+		}
 	}
 
 	return false


### PR DESCRIPTION
SMB311

- NegotiateContextOffset is only valid if the DialectRevision is 311
- NegotiateContextList too.

https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/63abf97c-0d09-47e2-88d6-6bfa552949a5

NegotiateContextOffset/Reserved2 (4 bytes): If the DialectRevision field is 0x0311, then this field specifies the offset, in bytes, from the beginning of the SMB2 header to the first 8-byte aligned negotiate context in NegotiateContextList; otherwise, the server MUST set this to 0 and the client MUST ignore it on receipt.

Fix -> Remove NegotiateContextOffset check code if SMB311
Fix -> Remove NegotiateContextList handle code if not SMB311