### PR TITLE
fix - limit maxReadSize (0x100000, 1,048,756)

### DIFF
--- a/client.go
+++ b/client.go
@@ -735,12 +735,18 @@ func (f *RemoteFile) ReadAt(b []byte, off int64) (n int, err error) {
 	return n, nil
 }
 
+// MaxReadSizeLimit limits maxReadSize from negoticate data
+const MaxReadSizeLimit = 0x100000
+
 func (f *RemoteFile) readAt(b []byte, off int64) (n int, err error) {
 	if off < 0 {
 		return -1, os.ErrInvalid
 	}
 
 	maxReadSize := int(f.fs.maxReadSize)
+	if maxReadSize > MaxReadSizeLimit {
+		maxReadSize = MaxReadSizeLimit
+	}
 
 	for {
 		switch {


### PR DESCRIPTION
Background
On Windows 10, smb2 protocol return maxReadSize, 0x800000.
but if length set 0x800000 on Read Request, smb server reset tcp
session. (it seems OS bug.)

Fix
If maxReadSize is over then 0x100000, it limit 0x100000
0x100000 is value that  windows 7, 10 smb client use to Read Request
even