### PR TITLE
add Readdir method for RemoteFileSystem

### DIFF
--- a/client.go
+++ b/client.go
@@ -97,6 +97,14 @@ func (fs *RemoteFileSystem) newFile(fd FileIdDecoder, name string) *RemoteFile {
 	return f
 }
 
+func (fs *RemoteFileSystem) Readdir(n int) ([]os.FileInfo, error) {
+	dir, err := fs.openFile("", os.O_RDONLY, 0)
+	if err != nil {
+		return nil, err
+	}
+	return dir.Readdir(n)
+}
+
 func (fs *RemoteFileSystem) Open(name string) (*RemoteFile, error) {
 	return fs.OpenFile(name, os.O_RDONLY, 0)
 }
@@ -105,7 +113,10 @@ func (fs *RemoteFileSystem) OpenFile(name string, flag int, perm os.FileMode) (*
 	if isInvalidPath(name, false) {
 		return nil, os.ErrInvalid
 	}
+	return fs.openFile(name, flag, perm)
+}
 
+func (fs *RemoteFileSystem) openFile(name string, flag int, perm os.FileMode) (*RemoteFile, error) {
 	var access uint32
 	switch flag & (os.O_RDONLY | os.O_WRONLY | os.O_RDWR) {
 	case os.O_RDONLY:


### PR DESCRIPTION
Maybe I misunderstood something but i could not find a method for reading the current directory of an open `RemoteFileSystem`. 

the api suggest something like:

```
	mount, err := sf.client.Mount(`\\127.0.0.1\data`)
	if err != nil {
		panic(err)
	}
        defer mount.Umount()
        rf, err := mount.Open("PATH_NAME")
	if err != nil {
		panic(err)
	}
        files, err := dir.Readdir(-1)
	if err != nil {
		panic(err)
	}
       ......
```
This is ok when you know the (or have an) path but when you want read the root the `isInvalidPath` method will return an error because it is not allow an empty string as argument what makes sense when opening an file but not for opening an file object to read the current directory.