### PR TITLE
Allow zero-length file paths to enable opening of root directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,4 @@
-smb2
-====
-
-[![Build Status](https://travis-ci.org/hirochachacha/go-smb2.svg?branch=master)](https://travis-ci.org/hirochachacha/go-smb2)
-[![GoDoc](https://godoc.org/github.com/hirochachacha/go-smb2?status.svg)](http://godoc.org/github.com/hirochachacha/go-smb2)
-
-Description
------------
-
-SMB2/3 client implementation.
-
-Installation
-------------
-
-`go get github.com/hirochachacha/go-smb2`
+Forked from https://github.com/hirochachacha/go-smb2
 
 Documentation
 -------------

--- a/client.go
+++ b/client.go
@@ -9,8 +9,8 @@ import (
 	"sync"
 	"time"
 
-	. "github.com/hirochachacha/go-smb2/internal/erref"
-	. "github.com/hirochachacha/go-smb2/internal/smb2"
+	. "github.com/omnifocal/go-smb2/internal/erref"
+	. "github.com/omnifocal/go-smb2/internal/smb2"
 )
 
 // Dialer contains options for func (*Dialer) Dial.

--- a/conn.go
+++ b/conn.go
@@ -8,8 +8,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	. "github.com/hirochachacha/go-smb2/internal/erref"
-	. "github.com/hirochachacha/go-smb2/internal/smb2"
+	. "github.com/omnifocal/go-smb2/internal/erref"
+	. "github.com/omnifocal/go-smb2/internal/smb2"
 )
 
 // Negotiator contains options for func (*Dialer) Dial.

--- a/errors.go
+++ b/errors.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	. "github.com/hirochachacha/go-smb2/internal/erref"
+	. "github.com/omnifocal/go-smb2/internal/erref"
 )
 
 type TimeoutError struct {

--- a/example_test.go
+++ b/example_test.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"os"
 
-	"github.com/hirochachacha/go-smb2"
+	"github.com/omnifocal/go-smb2"
 )
 
 func Example() {

--- a/feature.go
+++ b/feature.go
@@ -1,7 +1,7 @@
 package smb2
 
 import (
-	. "github.com/hirochachacha/go-smb2/internal/smb2"
+	. "github.com/omnifocal/go-smb2/internal/smb2"
 )
 
 // client

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/hirochachacha/go-smb2
+module github.com/omnifocal/go-smb2
 
 go 1.12
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/hirochachacha/go-smb2 v0.0.0-20170105012046-2cbb6a7d134e h1:XS78dHYNlaxlmuE6yTtQffc/BrIEOmJj9rIDcFb2ElY=
-github.com/hirochachacha/go-smb2 v0.0.0-20170105012046-2cbb6a7d134e/go.mod h1:RU3w0c0Bf9WHJ5OhUp7xefZwrmGTNUx49pSwNUEK2FA=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 h1:HuIa8hRrWRSrqYzx1qI49NNxhdi2PrY7gxVSq1JjLDc=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/initiator.go
+++ b/initiator.go
@@ -3,8 +3,8 @@ package smb2
 import (
 	"encoding/asn1"
 
-	"github.com/hirochachacha/go-smb2/internal/ntlm"
-	"github.com/hirochachacha/go-smb2/internal/spnego"
+	"github.com/omnifocal/go-smb2/internal/ntlm"
+	"github.com/omnifocal/go-smb2/internal/spnego"
 )
 
 type Initiator interface {

--- a/path.go
+++ b/path.go
@@ -65,7 +65,7 @@ func dir(path string) string {
 
 func isInvalidPath(path string, abs bool) bool {
 	if path == "" {
-		return true
+		return false
 	}
 
 	if strings.ContainsRune(path, '/') {

--- a/session.go
+++ b/session.go
@@ -12,11 +12,11 @@ import (
 	"hash"
 	"time"
 
-	"github.com/hirochachacha/go-smb2/internal/crypto/ccm"
-	"github.com/hirochachacha/go-smb2/internal/crypto/cmac"
+	"github.com/omnifocal/go-smb2/internal/crypto/ccm"
+	"github.com/omnifocal/go-smb2/internal/crypto/cmac"
 
-	. "github.com/hirochachacha/go-smb2/internal/erref"
-	. "github.com/hirochachacha/go-smb2/internal/smb2"
+	. "github.com/omnifocal/go-smb2/internal/erref"
+	. "github.com/omnifocal/go-smb2/internal/smb2"
 )
 
 func sessionSetup(conn *conn, i Initiator) (*session, error) {

--- a/sign_test.go
+++ b/sign_test.go
@@ -5,9 +5,9 @@ import (
 	"crypto/aes"
 	"encoding/hex"
 
-	"github.com/hirochachacha/go-smb2/internal/crypto/cmac"
+	"github.com/omnifocal/go-smb2/internal/crypto/cmac"
 
-	. "github.com/hirochachacha/go-smb2/internal/smb2"
+	. "github.com/omnifocal/go-smb2/internal/smb2"
 
 	"testing"
 )

--- a/tree_conn.go
+++ b/tree_conn.go
@@ -5,7 +5,7 @@ import (
 	"time"
 	"unicode/utf16"
 
-	. "github.com/hirochachacha/go-smb2/internal/smb2"
+	. "github.com/omnifocal/go-smb2/internal/smb2"
 )
 
 type treeConn struct {


### PR DESCRIPTION
According to the MS-SMB2 spec, a zero length file name in an SMB2 CREATE request indicates a request to open the root directory of the share.

https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/5606ad47-5ee0-437a-817e-70c366052962