### PR TITLE
Allow for empty path in isInvalidPath().

### DIFF
--- a/path.go
+++ b/path.go
@@ -64,6 +64,10 @@ func dir(path string) string {
 }
 
 func isInvalidPath(path string, abs bool) bool {
+	if len(path) == 0 {
+		return false
+	}
+
 	if strings.ContainsRune(path, '/') {
 		return true
 	}


### PR DESCRIPTION
I was trying to do `RemoteFile.Readdir()` on the root directory of my share, i.e., the equivalent of `dir \\hostname\sharename`.  The only way I could seem to do this was by first opening a file named `""` (empty string), but it seems `isInvalidPath()` assumes `len(path)>0` (see the `if` statement where it checks to see if the first character is `\`).  If there's another filename I can use instead of `""` I'd be happy to use that, but I tried `.`, `.\`, etc. and Samba always returned an error.  Attached is a simple fix that allows `""`.