### PR TITLE
copyBuffer when nr < len(buf) or nr is EOF missing last write

### DIFF
--- a/client.go
+++ b/client.go
@@ -1144,7 +1144,7 @@ func copyBuffer(r io.Reader, w io.Writer, buf []byte) (n int64, err error) {
 		if nr > 0 {
 			nw, ew := w.Write(buf[:nr])
 			if nw > 0 {
-				n += int64(nr)
+				n += int64(nw)
 			}
 			if ew != nil {
 				err = ew

--- a/client_test.go
+++ b/client_test.go
@@ -1,6 +1,7 @@
 package smb2
 
 import (
+	"bytes"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -340,5 +341,37 @@ SKIP_SYMLINK_TEST:
 	_, err = fs.Stat(testDir + `\new`)
 	if IsNotExist(err) {
 		t.Error("unexpected error:", err)
+	}
+}
+
+type partialReader struct {
+	buf *bytes.Buffer
+}
+
+func (p *partialReader) Read(b []byte) (int, error) {
+	if len(b) < 2 {
+		return p.buf.Read(b)
+	}
+	// read partial of b
+	return p.buf.Read(b[:len(b)/2])
+}
+
+func TestCopyBufferPartialRead(t *testing.T) {
+	bufIn := []byte("this is a partial read test data")
+	bufR := make([]byte, len(bufIn))
+	copy(bufR, bufIn)
+	p := &partialReader{
+		buf: bytes.NewBuffer(bufR),
+	}
+	var bufW bytes.Buffer
+	n, err := copyBuffer(p, &bufW, make([]byte, 8))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != int64(len(bufIn)) {
+		t.Fatal("size not equal")
+	}
+	if !bytes.Equal(bufIn, bufW.Bytes()) {
+		t.Fatal("data not equal")
 	}
 }


### PR DESCRIPTION
Fix bug here:

https://github.com/hirochachacha/go-smb2/issues/19