### PR TITLE
wait to enable session until the SessionSetupResposne is parsed

### DIFF
--- a/session.go
+++ b/session.go
@@ -222,8 +222,7 @@ func sessionSetup(conn *conn, i Initiator, ctx context.Context) (*session, error
 		}
 	}
 
-	// now, allow access from receiver
-	s.enableSession()
+
 
 	pkt, err = s.recv(rr)
 	if err != nil {
@@ -243,7 +242,8 @@ func sessionSetup(conn *conn, i Initiator, ctx context.Context) (*session, error
 	if NtStatus(PacketCodec(pkt).Status()) != STATUS_SUCCESS {
 		return nil, &InvalidResponseError{"broken session setup response format"}
 	}
-
+	// now, allow access from receiver
+	s.enableSession()
 	return s, nil
 }
 


### PR DESCRIPTION
I _think_ this should fix #26 in a safe way

The problem I was encountering was that the session was enabled before the last packet (`Session Setup Response, Error: STATUS_LOGON_FAILURE`) was fully received. When it was enabled, that packet was throwing an error that message signing was enabled. I had a workaround by sleeping for a second to make sure the packets were recieved, but I think this is better and shouldn't break anything. Let me know what you think