### PR TITLE
add NTLM Target Info; return broken session with error

### DIFF
--- a/client.go
+++ b/client.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	. "github.com/hirochachacha/go-smb2/internal/erref"
+	"github.com/hirochachacha/go-smb2/internal/ntlm"
 	. "github.com/hirochachacha/go-smb2/internal/smb2"
 )
 
@@ -47,11 +48,8 @@ func (d *Dialer) DialContext(tcpConn net.Conn, ctx context.Context) (*Client, er
 	}
 
 	s, err := sessionSetup(conn, d.Initiator, ctx)
-	if err != nil {
-		return nil, err
-	}
 
-	return &Client{s: s, ctx: context.Background()}, nil
+	return &Client{s: s, ctx: context.Background()}, err
 }
 
 // Client represents a SMB session.
@@ -67,6 +65,11 @@ func (c *Client) WithContext(ctx context.Context) *Client {
 // Logoff invalidates the current SMB session.
 func (c *Client) Logoff() error {
 	return c.s.logoff(c.ctx)
+}
+
+// TargetInfo returns the target info obtained during the NTLMSSP negotation
+func (c *Client) TargetInfo() ntlm.SessionTargetInfo {
+	return c.s.targetInfo
 }
 
 // Mount connects to a SMB tree.

--- a/internal/ntlm/client.go
+++ b/internal/ntlm/client.go
@@ -27,6 +27,8 @@ type Client struct {
 	session *Session
 }
 
+
+
 func (c *Client) Negotiate() (nmsg []byte, err error) {
 	//        NegotiateMessage
 	//   0-8: Signature
@@ -111,6 +113,8 @@ func (c *Client) Authenticate(cmsg []byte) (amsg []byte, err error) {
 	if info == nil {
 		return nil, errors.New("invalid target info format")
 	}
+
+
 
 	//        AuthenticateMessage
 	//   0-8: Signature
@@ -254,6 +258,9 @@ func (c *Client) Authenticate(cmsg []byte) (amsg []byte, err error) {
 		session.user = c.User
 		session.negotiateFlags = flags
 
+		session.setTargetInfo(info)
+
+
 		h.Reset()
 		h.Write(ntChallengeResponse[:16])
 		sessionBaseKey := h.Sum(nil)
@@ -313,3 +320,4 @@ func (c *Client) Authenticate(cmsg []byte) (amsg []byte, err error) {
 func (c *Client) Session() *Session {
 	return c.session
 }
+

--- a/internal/ntlm/session.go
+++ b/internal/ntlm/session.go
@@ -18,6 +18,16 @@ type Session struct {
 
 	clientHandle *rc4.Cipher
 	serverHandle *rc4.Cipher
+
+	targetInfo SessionTargetInfo
+}
+
+// ref: http://davenport.sourceforge.net/ntlm.html#type2MessageExample
+type SessionTargetInfo struct {
+	ServerName string
+	DomainName string
+	DnsServerName string
+	DnsDomainName string
 }
 
 func (s *Session) User() string {
@@ -130,4 +140,19 @@ func (s *Session) Unseal(dst, ciphertext []byte, seqNum uint32) ([]byte, uint32,
 	}
 
 	return ret, seqNum, nil
+}
+
+
+func (s *Session) setTargetInfo(targetInfoEncoder *targetInfoEncoder) {
+	targetInfoMap := targetInfoEncoder.InfoMap
+	s.targetInfo = SessionTargetInfo{
+		ServerName:    string(targetInfoMap[1]),
+		DomainName:    string(targetInfoMap[2]),
+		DnsServerName: string(targetInfoMap[3]),
+		DnsDomainName: string(targetInfoMap[4]),
+	}
+}
+
+func (s *Session) TargetInfo() (SessionTargetInfo) {
+	return s.targetInfo
 }


### PR DESCRIPTION
This implements my feature request #28 

Here's a sample demonstrating:

```
func main() {
	//otherSMB()
	conn, err := net.Dial("tcp", "172.16.13.100:445")
	must(err)
	defer conn.Close()

	d := &smb2.Dialer{
		Initiator: &smb2.NTLMInitiator{
			User:     "agreen",
			Password: "wrong password",
		},
	}

	c, err := d.Dial(conn)
	if err != nil {
		if strings.Contains(err.Error(), "logon is invalid") {
			fmt.Printf("[!] Bad creds. But herre's the target info:\n\t%+v\n", c.TargetInfo())
			os.Exit(1)
		} else {
			panic(err)
		}
	}
	defer c.Logoff()

	fmt.Println("Connected!")
```

Output:
```
$ go run main.go
[!] Bad creds. But herre's the target info:
	{ServerName:PDC01 DomainName:ROPNOP DnsServerName:pdc01.lab.ropnop.com DnsDomainName:lab.ropnop.com}
exit status 1
```

Let me know what you think or if there's a cleaner way to implement this!