### PR TITLE
BUGFIX: ReadFile should read from the RemoteFileSystem

### DIFF
--- a/client.go
+++ b/client.go
@@ -615,7 +615,7 @@ func (fs *RemoteFileSystem) ReadDir(dirname string) ([]os.FileInfo, error) {
 }
 
 func (fs *RemoteFileSystem) ReadFile(filename string) ([]byte, error) {
-	f, err := os.Open(filename)
+	f, err := fs.Open(filename)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
PR to address #32

Changes the ReadFile function to read from fs / RemoteFileSystem instead of the local filesystem. 