### PR TITLE
Fixing ASN.1 BER decryption when connecting to cDOT SMB server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 # Created by https://www.gitignore.io/api/go
 
+# idea
+.idea
+*.code-workspace
+
 ### Go ###
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 go:
   - 1.12
   - 1.13
+  - 1.14
   - tip
 os:
   - linux

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/hirochachacha/go-smb2
+module github.com/dragoscirjan/go-smb2
 
 go 1.12
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/dragoscirjan/go-smb2
+module github.com/hirochachacha/go-smb2
 
 go 1.12
 

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.12
 
 require (
 	github.com/geoffgarside/ber v1.1.0
-	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
+	golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de
 )

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/hirochachacha/go-smb2
 
 go 1.12
 
-require golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
+require (
+	github.com/geoffgarside/ber v1.1.0
+	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/geoffgarside/ber v1.1.0 h1:qTmFG4jJbwiSzSXoNJeHcOprVzZ8Ulde2Rrrifu5U9w=
+github.com/geoffgarside/ber v1.1.0/go.mod h1:jVPKeCbj6MvQZhwLYsGwaGI52oUorHoHKNecGT85ZCc=
 github.com/hirochachacha/go-smb2 v0.0.0-20170105012046-2cbb6a7d134e h1:XS78dHYNlaxlmuE6yTtQffc/BrIEOmJj9rIDcFb2ElY=
 github.com/hirochachacha/go-smb2 v0.0.0-20170105012046-2cbb6a7d134e/go.mod h1:RU3w0c0Bf9WHJ5OhUp7xefZwrmGTNUx49pSwNUEK2FA=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,12 @@
 github.com/geoffgarside/ber v1.1.0 h1:qTmFG4jJbwiSzSXoNJeHcOprVzZ8Ulde2Rrrifu5U9w=
 github.com/geoffgarside/ber v1.1.0/go.mod h1:jVPKeCbj6MvQZhwLYsGwaGI52oUorHoHKNecGT85ZCc=
-github.com/hirochachacha/go-smb2 v0.0.0-20170105012046-2cbb6a7d134e h1:XS78dHYNlaxlmuE6yTtQffc/BrIEOmJj9rIDcFb2ElY=
-github.com/hirochachacha/go-smb2 v0.0.0-20170105012046-2cbb6a7d134e/go.mod h1:RU3w0c0Bf9WHJ5OhUp7xefZwrmGTNUx49pSwNUEK2FA=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 h1:HuIa8hRrWRSrqYzx1qI49NNxhdi2PrY7gxVSq1JjLDc=
-golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de h1:ikNHVSjEfnvz6sxdSPCaPt572qowuyMDMJLLm3Db3ig=
+golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 h1:0GoQqolDA55aaLxZyTzK/Y2ePZzZTUrRacwib7cNsYQ=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/spnego/spnego.go
+++ b/internal/spnego/spnego.go
@@ -2,6 +2,7 @@ package spnego
 
 import (
 	"encoding/asn1"
+
 	"github.com/geoffgarside/ber"
 )
 
@@ -161,7 +162,7 @@ func EncodeNegTokenResp(state asn1.Enumerated, typ asn1.ObjectIdentifier, token,
 func DecodeNegTokenResp(bs []byte) (*NegTokenResp, error) {
 	var resp NegTokenResp
 
-	_, err = ber.UnmarshalWithParams(bs, &resp, "explicit,tag:1")
+	_, err := ber.UnmarshalWithParams(bs, &resp, "explicit,tag:1")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/spnego/spnego.go
+++ b/internal/spnego/spnego.go
@@ -2,6 +2,7 @@ package spnego
 
 import (
 	"encoding/asn1"
+	"github.com/geoffgarside/ber"
 )
 
 var (
@@ -162,7 +163,10 @@ func DecodeNegTokenResp(bs []byte) (*NegTokenResp, error) {
 
 	_, err := asn1.UnmarshalWithParams(bs, &resp, "explicit,tag:1")
 	if err != nil {
-		return nil, err
+		_, err = ber.UnmarshalWithParams(bs, &resp, "explicit,tag:1")
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &resp, nil

--- a/internal/spnego/spnego.go
+++ b/internal/spnego/spnego.go
@@ -1,7 +1,9 @@
 package spnego
 
 import (
+	"bytes"
 	"encoding/asn1"
+	"fmt"
 
 	"github.com/geoffgarside/ber"
 )
@@ -79,6 +81,14 @@ func DecodeNegTokenInit2(bs []byte) (*NegTokenInit2, error) {
 		return nil, err
 	}
 
+	bs1, err := asn1.MarshalWithParams(init, "application,tag:0")
+	if err != nil {
+		panic(err)
+	}
+	if !bytes.Equal(bs, bs1) {
+		fmt.Println("BER")
+	}
+
 	return &init.Init2[0], nil
 }
 
@@ -130,6 +140,14 @@ func DecodeNegTokenInit(bs []byte) (*NegTokenInit, error) {
 		return nil, err
 	}
 
+	bs1, err := asn1.MarshalWithParams(init, "application,tag:0")
+	if err != nil {
+		panic(err)
+	}
+	if !bytes.Equal(bs, bs1) {
+		fmt.Println("BER")
+	}
+
 	return &init.Init[0], nil
 }
 
@@ -165,6 +183,14 @@ func DecodeNegTokenResp(bs []byte) (*NegTokenResp, error) {
 	_, err := ber.UnmarshalWithParams(bs, &resp, "explicit,tag:1")
 	if err != nil {
 		return nil, err
+	}
+
+	bs1, err := asn1.MarshalWithParams(resp, "application,tag:0")
+	if err != nil {
+		panic(err)
+	}
+	if !bytes.Equal(bs, bs1) {
+		fmt.Println("BER")
 	}
 
 	return &resp, nil

--- a/internal/spnego/spnego.go
+++ b/internal/spnego/spnego.go
@@ -73,7 +73,7 @@ type NegTokenResp struct {
 func DecodeNegTokenInit2(bs []byte) (*NegTokenInit2, error) {
 	var init initialContextToken2
 
-	_, err := asn1.UnmarshalWithParams(bs, &init, "application,tag:0")
+	_, err := ber.UnmarshalWithParams(bs, &init, "application,tag:0")
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +124,7 @@ func EncodeNegTokenInit(types []asn1.ObjectIdentifier, token []byte) ([]byte, er
 func DecodeNegTokenInit(bs []byte) (*NegTokenInit, error) {
 	var init initialContextToken
 
-	_, err := asn1.UnmarshalWithParams(bs, &init, "application,tag:0")
+	_, err := ber.UnmarshalWithParams(bs, &init, "application,tag:0")
 	if err != nil {
 		return nil, err
 	}
@@ -161,12 +161,9 @@ func EncodeNegTokenResp(state asn1.Enumerated, typ asn1.ObjectIdentifier, token,
 func DecodeNegTokenResp(bs []byte) (*NegTokenResp, error) {
 	var resp NegTokenResp
 
-	_, err := asn1.UnmarshalWithParams(bs, &resp, "explicit,tag:1")
+	_, err = ber.UnmarshalWithParams(bs, &resp, "explicit,tag:1")
 	if err != nil {
-		_, err = ber.UnmarshalWithParams(bs, &resp, "explicit,tag:1")
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 
 	return &resp, nil


### PR DESCRIPTION
Hi!

There's a thing in this world, called cDOT, which is an OS developed by [NetApp](https://www.netapp.com/) which also implements an SMB server similar to or based on the SAMBA one, **but** using BER encoding instead of DER for the auth messages.

Since Go's ASN.1 implementation supports only DER, I had to add another package (claims to be a fork of `encoding/asn1`) which implements BER as well.

You have a possible solution for this bellow. 
Considering there may be other SMB implementations around there which may use BER encoding @ auth level, I hope it will benefit everyone :)