### PR TITLE
Support for older go versions.

### DIFF
--- a/path.go
+++ b/path.go
@@ -99,7 +99,7 @@ func normPath(path string) string {
 	if !NORMALIZE_PATH {
 		return path
 	}
-	path = strings.ReplaceAll(path, `/`, `\`)
+	path = strings.Replace(path, `/`, `\`, -1)
 	for strings.HasPrefix(path, `.\`) {
 		path = path[2:]
 	}


### PR DESCRIPTION
Hello

I've just updated very simple string replace function to support older versions of go. Should be supported generally, I've tested with 1.11 which is in stable repository of Debian 10.