### PR TITLE
feat: add (File).ReaddirPattern (Share).ReadDirPattern methods

### DIFF
--- a/client.go
+++ b/client.go
@@ -784,6 +784,9 @@ func (fs *Share) ReadDir(dirname string) ([]os.FileInfo, error) {
 	return fs.ReadDirPattern(dirname, "*")
 }
 
+// ReadDirPattern performs a readdir with a pattern.
+// The match will be done according to the specification https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/dc92d939-ec45-40c8-96e5-4c4091e4ab43
+// See the glob sub-package for a behavior closer to filepath.Glob
 func (fs *Share) ReadDirPattern(dirname, pattern string) ([]os.FileInfo, error) {
 	f, err := fs.Open(dirname)
 	if err != nil {
@@ -1222,6 +1225,9 @@ func (f *File) Readdir(n int) (fi []os.FileInfo, err error) {
 	return f.ReaddirPattern(n, "*")
 }
 
+// ReadDirPattern performs a readdir with a pattern.
+// The match will be done according to the specification https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/dc92d939-ec45-40c8-96e5-4c4091e4ab43
+// See the glob sub-package for a behavior closer to filepath.Glob
 func (f *File) ReaddirPattern(n int, pattern string) (fi []os.FileInfo, err error) {
 	f.m.Lock()
 	defer f.m.Unlock()

--- a/glob/filepath.go
+++ b/glob/filepath.go
@@ -1,0 +1,121 @@
+package glob
+
+import (
+	"errors"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/hirochachacha/go-smb2"
+)
+
+// ErrBadPattern indicates a pattern was malformed.
+var ErrBadPattern = errors.New("syntax error in pattern")
+
+func normPattern(pattern string) string {
+	if !smb2.NORMALIZE_PATH {
+		return pattern
+	}
+	pattern = strings.ReplaceAll(pattern, `/`, `\`)
+	for strings.HasPrefix(pattern, `.\`) {
+		pattern = pattern[2:]
+	}
+	return pattern
+}
+
+func join(elem ...string) string {
+	return strings.Join(elem, string(smb2.PathSeparator))
+}
+
+func split(path string) (dir, file string) {
+	i := len(path) - 1
+	for i >= 0 && !smb2.IsPathSeparator(path[i]) {
+		i--
+	}
+	return path[:i+1], path[i+1:]
+}
+
+// Find should work like filepath.Glob.
+func Find(fs *smb2.Share, pattern string) (matches []string, err error) {
+	pattern = normPattern(pattern)
+
+	if !hasMeta(pattern) {
+		if _, err = fs.Lstat(pattern); err != nil {
+			return nil, nil
+		}
+		return []string{pattern}, nil
+	}
+
+	dir, file := split(pattern)
+
+	dir = cleanGlobPath(dir)
+
+	if !hasMeta(dir) {
+		return glob(fs, dir, file, nil)
+	}
+
+	// Prevent infinite recursion.
+	if dir == pattern {
+		return nil, ErrBadPattern
+	}
+
+	var m []string
+	m, err = Find(fs, dir)
+	if err != nil {
+		return
+	}
+	for _, d := range m {
+		matches, err = glob(fs, d, file, matches)
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+// cleanGlobPath prepares path for glob matching.
+func cleanGlobPath(path string) string {
+	switch path {
+	case "":
+		return "."
+	case string(smb2.PathSeparator):
+		// do nothing to the path
+		return path
+	default:
+		return path[0 : len(path)-1] // chop off trailing separator
+	}
+}
+
+var characterRangePattern = regexp.MustCompile(`\[^?[^\[\]]+\]`)
+
+func generalizePattern(pattern string) string {
+	return characterRangePattern.ReplaceAllLiteralString(pattern, "?")
+}
+
+// glob searches for files matching pattern in the directory dir
+// and appends them to matches. If the directory cannot be
+// opened, it returns the existing matches. New matches are
+// added in lexicographical order.
+func glob(fs *smb2.Share, dir, pattern string, matches []string) (m []string, e error) {
+	escapedPattern := strings.ReplaceAll(pattern, `\`, `\\`)
+	dirents, err := fs.ReadDirPattern(dir, generalizePattern(pattern))
+	for _, st := range dirents {
+		name := st.Name()
+		if ok, err := filepath.Match(escapedPattern, name); ok {
+			matches = append(matches, join(dir, name))
+		} else if err != nil {
+			return matches, err
+		}
+	}
+
+	sort.Strings(matches)
+
+	return matches, err
+}
+
+// hasMeta reports whether path contains any of the magic characters
+// recognized by Match.
+func hasMeta(path string) bool {
+	return strings.ContainsAny(path, `*?[`)
+}

--- a/glob/filepath_test.go
+++ b/glob/filepath_test.go
@@ -1,0 +1,19 @@
+package glob
+
+import (
+	"testing"
+)
+
+func TestSimplifyPattern(t *testing.T) {
+	cases := [][2]string{
+		{"test.ext", "test.ext"},
+		{"ab[0-9].ext", "ab?.ext"},
+		{"tes?", "tes?"},
+	}
+
+	for _, tt := range cases {
+		if generalizePattern(tt[0]) != tt[1] {
+			t.Errorf("generalizePattern(%q) = %q, want %q", tt[0], generalizePattern(tt[0]), tt[1])
+		}
+	}
+}


### PR DESCRIPTION
Hi,

thank you for this library!

Since SMB natively supports reading only a specific pattern while listing the content of a directory, I thought it would be nice to add two methods to the API to support this: `(File).ReaddirPattern` and `(Share).ReadDirPattern` (maybe you have a suggestion for a better name?).

Since those are just additions, this is not a breaking change.

I have refactored the code, so that the methods `Readdir` and `ReadDir` simply call the newly created methods with the `*` pattern.

I would appreciate any comment or suggestions regarding this PR :smile: 