### PR TITLE
Fix variable name in example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ func main() {
 		fmt.Println(match)
 	}
 
-	err = iofs.WalkDir(fs.DirFS("."), ".", func(path string, d fs.DirEntry, err error) error {
+	err = iofs.WalkDir(fs.DirFS("."), ".", func(path string, d iofs.DirEntry, err error) error {
 		fmt.Println(path, d, err)
 
 		return nil


### PR DESCRIPTION
Hi, thanks for this useful implementation.

I tried the example in README.md and got a build error, so I fixed the part where the error occurred.

The following process an error occurred:
```bash
$ go version
go version go1.18.1 linux/amd64

$ go build
# example
./main.go:45:64: fs.DirEntry undefined (type *"github.com/hirochachacha/go-smb2".Share has no field or method DirEntry)
```

References of implementation:

https://github.com/hirochachacha/go-smb2/blob/82da9adcf15307deb147fbe4a0732d0e0b657e2c/smb2_fs_test.go#L60