### PR TITLE
feat: returns negotiated dialect

### DIFF
--- a/client.go
+++ b/client.go
@@ -221,6 +221,14 @@ func (c *Session) ListSharenames() ([]string, error) {
 	return r2.ShareNameList(), nil
 }
 
+// NegotiatedDialect returns negotiated dialect.
+func (c *Session) NegotiatedDialect() uint16 {
+	if c.s != nil {
+		return c.s.dialect
+	}
+	return UnknownSMB
+}
+
 // Share represents a SMB tree connection with VFS interface.
 type Share struct {
 	*treeConn


### PR DESCRIPTION
Expose the negotiated dialect is useful, such as mount.cifs not support auto
negotiate, we can negotiate a smb protocol version with this package and select
a protocol version supported by mount.cifs.
