### PR TITLE
Update conn.go to cover the STATUS_NO_MORE_FILES status response

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -611,6 +611,8 @@ func accept(cmd uint16, pkt []byte) (res []byte, err error) {
 		return nil, os.ErrNotExist
 	case STATUS_ACCESS_DENIED, STATUS_CANNOT_DELETE:
 		return nil, os.ErrPermission
+	case STATUS_NO_MORE_FILES:
+		return nil, &ResponseError{Code: uint32(status)}
 	}
 
 	switch cmd {


### PR DESCRIPTION
Update **conn.go** to fix the problem that the STATUS_NO_MORE_FILES status is not handled correctly

The [`accept` method](https://github.com/hirochachacha/go-smb2/blob/c8e61c7a5fa7bcd1143359f071f9425a9f4dda3f/conn.go#L597) does not cover the case of STATUS_NO_MORE_FILES response status, which makes the code snippet (in souce code [line 1281 in client.go](https://github.com/hirochachacha/go-smb2/blob/c8e61c7a5fa7bcd1143359f071f9425a9f4dda3f/client.go#L1281C26-L1281C26)) could not handle the reponse as expected (as a STATUS_NO_MORE_FILES response).