### PR TITLE
Rename should use replace semantics like os.rename

### DIFF
--- a/client.go
+++ b/client.go
@@ -509,7 +509,7 @@ func (fs *Share) Rename(oldpath, newpath string) error {
 		FileInfoClass:         FileRenameInformation,
 		AdditionalInformation: 0,
 		Input: &FileRenameInformationType2Encoder{
-			ReplaceIfExists: 0,
+			ReplaceIfExists: 1,
 			RootDirectory:   0,
 			FileName:        newpath,
 		},


### PR DESCRIPTION
Rename should try to replace the existing file if the new name conflicts with an existing filename.
Among other things, this allows renaming alternate data streams, specifically renaming an alternate stream to a default one.