### PR TITLE
Fix: [Issue-101] Panic: runtime error: slice bounds out of range in PacketCodec.SessionId()

### DIFF
--- a/internal/smb2/packet.go
+++ b/internal/smb2/packet.go
@@ -189,10 +189,16 @@ func (p PacketCodec) SetTreeId(u uint32) {
 }
 
 func (p PacketCodec) SessionId() uint64 {
+	if len(p) < 48 {
+		return 0
+	}
 	return le.Uint64(p[40:48])
 }
 
 func (p PacketCodec) SetSessionId(u uint64) {
+	if len(p) < 48 {
+		return
+	}
 	le.PutUint64(p[40:48], u)
 }
 


### PR DESCRIPTION
Issue link: https://github.com/hirochachacha/go-smb2/issues/101#issue-3050481928

Change:
- validate packet before accessing sessionID.